### PR TITLE
Fix/mppi reference trajectory segfault

### DIFF
--- a/mppi/include/mppi/cost/cost_base.h
+++ b/mppi/include/mppi/cost/cost_base.h
@@ -9,6 +9,7 @@
 #pragma once
 #include <Eigen/Core>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include "mppi/typedefs.h"
 
@@ -21,9 +22,9 @@ class CostBase {
   using cost_vector_t = Eigen::VectorXd;
 
   CostBase() = default;
+  CostBase(const CostBase& cost_base);
   ~CostBase() = default;
 
- public:
   virtual cost_ptr create() = 0;       // virtual constructor
   virtual cost_ptr clone() const = 0;  // virtual copy constructor
 
@@ -68,6 +69,7 @@ class CostBase {
  // private:
   reference_t r_;
   reference_trajectory_t timed_ref_;
+  mutable std::shared_mutex timed_reference_mutex_;
 };
 
 }  // end of namespace mppi

--- a/mppi/src/cost/cost_base.cpp
+++ b/mppi/src/cost/cost_base.cpp
@@ -11,19 +11,30 @@
 
 namespace mppi {
 
+CostBase::CostBase(const CostBase &cost_base) {
+  std::shared_lock lock(cost_base.timed_reference_mutex_);
+  timed_ref_ = cost_base.timed_ref_;
+  r_ = cost_base.r_;
+}
+
 void CostBase::set_reference_trajectory(const reference_trajectory_t &traj) {
-  // TODO try direct copy
-  timed_ref_.tt.clear();
-  timed_ref_.tt.reserve(traj.tt.size());
-  timed_ref_.rr.clear();
-  for (size_t i = 0; i < traj.tt.size(); i++) {
-    timed_ref_.rr.push_back(traj.rr[i]);
-    timed_ref_.tt.push_back(traj.tt[i]);
+  if (traj.rr.size() > 0 && traj.tt.size() > 0) {
+    std::scoped_lock lock(timed_reference_mutex_);
+
+    timed_ref_.tt.clear();
+    timed_ref_.tt.reserve(traj.tt.size());
+    timed_ref_.rr.clear();
+    for (size_t i = 0; i < traj.tt.size(); i++) {
+      timed_ref_.rr.push_back(traj.rr[i]);
+      timed_ref_.tt.push_back(traj.tt[i]);
+    }
   }
 }
 
 void CostBase::interpolate_reference(const observation_t & /*x*/,
                                      reference_t &ref, const double t) {
+  std::shared_lock lock(timed_reference_mutex_);
+
   auto lower = std::lower_bound(timed_ref_.tt.begin(), timed_ref_.tt.end(), t);
   size_t offset = std::distance(timed_ref_.tt.begin(), lower);
   if (lower == timed_ref_.tt.end() && offset > 0) offset -= 1;

--- a/mppi/src/cost/cost_base.cpp
+++ b/mppi/src/cost/cost_base.cpp
@@ -18,16 +18,9 @@ CostBase::CostBase(const CostBase &cost_base) {
 }
 
 void CostBase::set_reference_trajectory(const reference_trajectory_t &traj) {
-  if (traj.rr.size() > 0 && traj.tt.size() > 0) {
+  if (!traj.rr.empty() && !traj.tt.empty()) {
     std::scoped_lock lock(timed_reference_mutex_);
-
-    timed_ref_.tt.clear();
-    timed_ref_.tt.reserve(traj.tt.size());
-    timed_ref_.rr.clear();
-    for (size_t i = 0; i < traj.tt.size(); i++) {
-      timed_ref_.rr.push_back(traj.rr[i]);
-      timed_ref_.tt.push_back(traj.tt[i]);
-    }
+    timed_ref_ = traj;
   }
 }
 

--- a/mppi/src/cost/cost_base.cpp
+++ b/mppi/src/cost/cost_base.cpp
@@ -27,7 +27,7 @@ void CostBase::interpolate_reference(const observation_t & /*x*/,
   auto lower = std::lower_bound(timed_ref_.tt.begin(), timed_ref_.tt.end(), t);
   size_t offset = std::distance(timed_ref_.tt.begin(), lower);
   if (lower == timed_ref_.tt.end() && offset > 0) offset -= 1;
-  ref = timed_ref_.rr[offset];
+  ref = timed_ref_.rr.at(offset);
 }
 
 CostBase::cost_t CostBase::get_stage_cost(const mppi::observation_t &x,


### PR DESCRIPTION
Fixes the segfault which makes the mppi controller always crash after a few seconds.
/!\ should be tested on the drone/other computer before merging 